### PR TITLE
Update 02.terms.md

### DIFF
--- a/02.terms.md
+++ b/02.terms.md
@@ -49,18 +49,23 @@ Decoded frame
 
 : The frame reconstructed out of the bitstream by the decoder.
 
-Decoder
+Video decoder
 
-: One embodiment of the decoding process.
+: One embodiment of the video decoding process.
 
-[AMT]: # (In this spec, should we be talking about an encoding and decoding process? Or is the encoding/decoding about the video data, the film grain parameters, or both? It seems to me that we may need to even define "synthesis" and grain adition here instead of talking about decoding )
-
-Decoding process
+Video decoding process
 
 : The process that derives decoded frames from syntax elements, including any processing 
-  steps used prior to and for the film grain synthesis process.
+  steps used prior to and generating decoded video frames.
 
-[AMT]: # (See my above comments. We should define a film grain parameter decoding process and film grain synthesis and addition processes, and not talk about decoding here. Right? Same for Encoder and Decoder. The definition above seems incorrect in any case given the scope of this document. Maybe as a suggestion, the decoding process here should be about "the process that derives the film grain synthesis parameters from syntax elements", instead of what is defined above)
+Film grain decoding process
+
+: The process that derives film grain parameters from syntax elements, including any processing 
+  steps used  for the film grain synthesis process.
+
+Film grain synthesis module
+
+[ToDo] Add a definition of the fgs decoding process and module and adjust the specification text accordingly.
 
 Encoder
 
@@ -72,6 +77,7 @@ Encoding process
   that conforms to the description provided in this document.
 
   [AMT]: # (This encoding process is only for the film grain parameters)
+[ToDo] Adjust the definition of the encoding process and its usage in the specification (e.g. a film grain analyzer).
 
 Flag
 
@@ -127,6 +133,8 @@ Reconstruction
   prediction values.
 
   [AMT]: # (I would assume that here we reconstruct noise and we add it on the images. There is no residual. Correct? We likely need to redefine this term for this document assuming it is needed. Same for other terms in this document, such as "reference")
+[ToDo] Clean-up the reconstruction usage in this specification.
+  
   
 Reference
 
@@ -143,11 +151,9 @@ Sample
 
 Sample value
 
-: The value of a sample. This is an integer from 0 to 255 (inclusive) for 8-bit
-  frames, from 0 to 1023 (inclusive) for 10-bit frames, and from 0 to 4095
-  (inclusive) for 12-bit frames.
+: The value of a sample. This is an number in the range from the minimum sample value to the maximum sample value.
 
-   [AMT]: # (This should not be restricted to the bitdepths supported in AV1. Other video technologies may support other bitdepths and this should be generic. Q: Do we have the flexibility to indicate different bitdepths in this spec? If not, should we have?)
+[ToDo] Check if the reference synthesis process supports the bit depths outside of the 8 to 12 bit range.
 
 Sequence
 

--- a/02.terms.md
+++ b/02.terms.md
@@ -9,8 +9,8 @@ Bitstream
 
 Bit string
 
-: An ordered string with limited number of bits. The left most bit is the most
-  significant bit (MSB), the right most bit is the least significant bit (LSB).
+: An ordered string with a limited number of bits. The left most bit is the most
+  significant bit (MSB) and the right most bit is the least significant bit (LSB).
 
 Byte
 
@@ -18,7 +18,7 @@ Byte
 
 Byte alignment
 
-: One bit is byte aligned if the position of the bit is an integer multiple of
+: One bit, byte, or syntax element is byte aligned if the position of the bit, byte, or syntax element, respectively in the bitstream is an integer multiple of
   eight from the position of the first bit in the bitstream.
 
 Chroma
@@ -35,8 +35,8 @@ Coded frame
 
 Coded video sequence
 
-: Coded video sequence is a sequence of access units or temporal units that
-consists of a random access point which is followed by zero or more access
+: A coded video sequence is a sequence of access units or temporal units that
+consists of a random access point, which is followed by zero or more access
 units or temporal units up to but not including the subsequent random access
 point.
 
@@ -53,10 +53,14 @@ Decoder
 
 : One embodiment of the decoding process.
 
+[AMT]: # (In this spec, should we be talking about an encoding and decoding process? Or is the encoding/decoding about the video data, the film grain parameters, or both? It seems to me that we may need to even define "synthesis" and grain adition here instead of talking about decoding )
+
 Decoding process
 
 : The process that derives decoded frames from syntax elements, including any processing 
   steps used prior to and for the film grain synthesis process.
+
+[AMT]: # (See my above comments. We should define a film grain parameter decoding process and film grain synthesis and addition processes, and not talk about decoding here. Right? Same for Encoder and Decoder. The definition above seems incorrect in any case given the scope of this document. Maybe as a suggestion, the decoding process here should be about "the process that derives the film grain synthesis parameters from syntax elements", instead of what is defined above)
 
 Encoder
 
@@ -67,10 +71,12 @@ Encoding process
 : A process not specified in this Specification that generates the bitstream
   that conforms to the description provided in this document.
 
+  [AMT]: # (This encoding process is only for the film grain parameters)
+
 Flag
 
 : A binary variable - some variables and syntax elements (e.g.
-  obu_extension_flag) are described using the word flag to highlight that the
+  luma_only_grain) are described using the word flag to highlight that the
   syntax element can only be equal to 0 or equal to 1.
 
 Frame
@@ -119,6 +125,8 @@ Reconstruction
 
 : Obtaining the addition of the decoded residual and the corresponding
   prediction values.
+
+  [AMT]: # (I would assume that here we reconstruct noise and we add it on the images. There is no residual. Correct? We likely need to redefine this term for this document assuming it is needed. Same for other terms in this document, such as "reference")
   
 Reference
 
@@ -138,6 +146,8 @@ Sample value
 : The value of a sample. This is an integer from 0 to 255 (inclusive) for 8-bit
   frames, from 0 to 1023 (inclusive) for 10-bit frames, and from 0 to 4095
   (inclusive) for 12-bit frames.
+
+   [AMT]: # (This should not be restricted to the bitdepths supported in AV1. Other video technologies may support other bitdepths and this should be generic. Q: Do we have the flexibility to indicate different bitdepths in this spec? If not, should we have?)
 
 Sequence
 


### PR DESCRIPTION
Added several comments. A lot of the terms seem not appropriate and related more to the video signals than the film grain itself. We likely need to remove or adjust many of the terms here.