### PR TITLE
05.payload cleanup

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -10,11 +10,8 @@ each of the syntax elements is presented in [Section 6][].
 | --------------------------------------------------------- | ---------------- |
 | metadata_itut_t35( ) {                                    | **Type**
 |     @@itu_t_t35_country_code                              | f(8)
-|     if ( itu_t_t35_country_code == 0xB5 ) {
-|         @@itu_t_t35_terminal_provider_code                | f(16)
-|         if ( itu_t_t35_terminal_provider_code == 0x5890 ) {
-|             aom_itu_t_t35_payload()
-|     }
+|     @@itu_t_t35_terminal_provider_code                    | f(16)
+|     aom_itu_t_t35_payload()
 | }
 {:.syntax }
 

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -8,7 +8,7 @@ each of the syntax elements is presented in [Section 6][].
 ### AOMedia ITU-T T.35 metadata syntax
 
 | --------------------------------------------------------- | ---------------- |
-| metadata_itut_t35( ) {                                    | **Type**
+| metadata_aom_itu_t_t35( ) {                                    | **Type**
 |     @@itu_t_t35_country_code                              | f(8)
 |     @@itu_t_t35_terminal_provider_code                    | f(16)
 |     @@itu_t_t35_terminal_provider_oriented_code           | f(8)
@@ -16,9 +16,6 @@ each of the syntax elements is presented in [Section 6][].
 | }
 {:.syntax }
 
-**Note:** The syntax above represents signaling of ITU-T T.35 metadata
-reserved for AOMedia and not general ITU-T T.35 syntax.
-{:.alert .alert-info }
 
 ### Film grain parameter sets syntax
 

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -32,10 +32,7 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 | --------------------------------------------------------- | ---------------- |
 |aom_itu_t_t35_payload( ) {                                 | **Type**
 |     @@itu_t_t35_terminal_provider_oriented_code           | f(8)
-|     if ( itu_t_t35_terminal_provider_oriented_code == 0x01 ) {
-|         av1_film_grain_param_sets( )
-|     }
-| }
+|     av1_film_grain_param_sets( )
 {:.syntax }
 
 ### Film grain parameter sets syntax

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -38,18 +38,6 @@ at least one byte of the payload data (including the trailing bit) shall not be 
 | }
 {:.syntax }
 
-**Note:** This specification only provides the value of the
-itu_t_t35_terminal_provider_oriented_code that
-identifies the av1 film grain parameters metadata.
-The complete syntax of aom_itu_t_t35_payload( ) and the list of values for
-AOMedia itu_t_t35_terminal_provider_oriented_code are outside the scope of this specification.
-{:.alert .alert-info }
-
-**Note:** The syntax tables above define the signaling of the AFGS film grain parameter
-information as user data registered according to ITU-T Recommendation T.35.  Other methods 
-for indicating the av1_film_grain_param_sets( ) are also allowed.
-{:.alert .alert-info }
-
 ### Film grain parameter sets syntax
 
 | ----------------------------------------------------------------- | ---------------- |

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -12,7 +12,6 @@ each of the syntax elements is presented in [Section 6][].
 |     @@itu_t_t35_country_code                              | f(8)
 |     @@itu_t_t35_terminal_provider_code                    | f(16)
 |     aom_itu_t_t35_payload()
-|     @@trailing_one_bit                                    | f(1)
 | }
 {:.syntax }
 

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -12,15 +12,12 @@ each of the syntax elements is presented in [Section 6][].
 |     @@itu_t_t35_country_code                              | f(8)
 |     @@itu_t_t35_terminal_provider_code                    | f(16)
 |     aom_itu_t_t35_payload()
+|     @@trailing_one_bit                                    | f(1)
 | }
 {:.syntax }
 
-**Note:** The last byte of the valid content of the data is
-considered to be the last byte that is not equal to zero. This rule is to
-prevent the dropping of valid bytes by systems that interpret trailing zero
-bytes as a padding continuation of the trailing bits.
-This implies that when any payload data is present,
-at least one byte of the payload data (including the trailing bit) shall not be equal to 0.
+**Note:** The syntax above represents signaling of ITU-T T.35 metadata
+reserved for AOMedia and not general ITU-T T.35 syntax.
 {:.alert .alert-info }
 
 

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -11,22 +11,14 @@ each of the syntax elements is presented in [Section 6][].
 | metadata_itut_t35( ) {                                    | **Type**
 |     @@itu_t_t35_country_code                              | f(8)
 |     @@itu_t_t35_terminal_provider_code                    | f(16)
-|     aom_itu_t_t35_payload()
+|     @@itu_t_t35_terminal_provider_oriented_code           | f(8)
+|     av1_film_grain_param_sets( )
 | }
 {:.syntax }
 
 **Note:** The syntax above represents signaling of ITU-T T.35 metadata
 reserved for AOMedia and not general ITU-T T.35 syntax.
 {:.alert .alert-info }
-
-
-### AOMedia ITU-T T.35 payload syntax
-
-| --------------------------------------------------------- | ---------------- |
-|aom_itu_t_t35_payload( ) {                                 | **Type**
-|     @@itu_t_t35_terminal_provider_oriented_code           | f(8)
-|     av1_film_grain_param_sets( )
-{:.syntax }
 
 ### Film grain parameter sets syntax
 

--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -12,7 +12,9 @@ each of the syntax elements is presented in [Section 6][].
 |     @@itu_t_t35_country_code                              | f(8)
 |     @@itu_t_t35_terminal_provider_code                    | f(16)
 |     @@itu_t_t35_terminal_provider_oriented_code           | f(8)
-|     av1_film_grain_param_sets( )
+|     if ( itu_t_t35_terminal_provider_oriented_code == 0x01 ) {
+|         av1_film_grain_param_sets( )
+|     }
 | }
 {:.syntax }
 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -17,8 +17,6 @@ to 0xB5 for bitstreams conforming to this version of the specification.
 provider code in an ITU-T T.35 user registered metadata syntax.  itu_t_t35_terminal_provider_code 
 shall be equal to 0x5890 for bitstreams conforming to this version of the  specification.
 
-**trailing_one_bit** shall be equal to 1
-
 ### AOMedia ITU-T T.35 payload semantics
 
 **itu_t_t35_terminal_provider_oriented_code** shall be equal to 0x0001 for bitstreams 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -9,14 +9,13 @@ Important variables and function calls are also described.
 
 ### AOMedia ITU-T T.35 metadata semantics
 
-**itu_t_t35_country_code** is a syntax element that corresponds to the syntax element itu_t_t35_terminal_provider_code in an ITU-T T.35 user registered metadata syntax. Its value shall be equal to 0xB5, which indicates that the
-itu_t_t35_terminal_provider_code is registered in the United States.
+**itu_t_t35_country_code** is a syntax element that corresponds to the country code
+in an ITU-T T.35 user registered metadata syntax.  itu_t_t35_country_code shall be equal
+to 0xB5 for bitstreams conforming to this version of the specification.
 
-**itu_t_t35_terminal_provider_code** are two bytes having values specified as a terminal
-provider code in
-[reference name required](https://cdn.cta.tech/cta/media/media/resources/standards/pdfs/manucode_2020-2.pdf).
-itu_t_t35_terminal_provider_code equal to 0x5890 indicates that the ITU-T T.35 payload is
-specified by AOMedia.
+**itu_t_t35_terminal_provider_code** is a syntax element that corresponds to a terminal
+provider code in an ITU-T T.35 user registered metadata syntax.  itu_t_t35_terminal_provider_code 
+shall be equal to 0x5890 for bitstreams conforming to this version of the  specification.
 
 ### AOMedia ITU-T T.35 payload semantics
 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -17,9 +17,7 @@ to 0xB5 for bitstreams conforming to this version of the specification.
 provider code in an ITU-T T.35 user registered metadata syntax.  itu_t_t35_terminal_provider_code 
 shall be equal to 0x5890 for bitstreams conforming to this version of the  specification.
 
-### AOMedia ITU-T T.35 payload semantics
-
-**itu_t_t35_terminal_provider_oriented_code** shall be equal to 0x0001 for bitstreams 
+**itu_t_t35_terminal_provider_oriented_code** shall be equal to 0x01 for bitstreams 
 conforming to this version of the specification.
 
 ### Film grain parameter sets semantics

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -17,6 +17,8 @@ to 0xB5 for bitstreams conforming to this version of the specification.
 provider code in an ITU-T T.35 user registered metadata syntax.  itu_t_t35_terminal_provider_code 
 shall be equal to 0x5890 for bitstreams conforming to this version of the  specification.
 
+**trailing_one_bit** shall be equal to 1
+
 ### AOMedia ITU-T T.35 payload semantics
 
 **itu_t_t35_terminal_provider_oriented_code** shall be equal to 0x0001 for bitstreams 

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -20,11 +20,8 @@ specified by AOMedia.
 
 ### AOMedia ITU-T T.35 payload semantics
 
-**itu_t_t35_terminal_provider_oriented_code** provides the value of the
-ITU-T T.35 terminal provider oriented code that is defined
-in the [AOMedia metadata registry](https://aomediacodec.github.io/metadata-registry/) specification.
-itu_t_t35_terminal_provider_oriented_code equal to 0x0001 indicates that the ITU-T T.35 payload
-contains AOMedia film grain parameters, as defined by this specification.
+**itu_t_t35_terminal_provider_oriented_code** shall be equal to 0x0001 for bitstreams 
+conforming to this version of the specification.
 
 ### Film grain parameter sets semantics
 


### PR DESCRIPTION
Editorial improvements of the T.35 metadata and payload syntax (and semantics)
- Remove reference to the AOMedia metadata registry
- Simplify the payload and metadata syntax
- Address the note regarding the last byte needing to be non-zero

close #22