### PR TITLE
Check for num_y_points, num_cb_points, and num_cr_points

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -101,7 +101,7 @@ in the [AOMedia metadata registry](https://aomediacodec.github.io/metadata-regis
 |          subsampling_y                                    | f(1)
 |          SubY = subsampling_y
 |     }
-|     @@video_signal_characteristics_flag                    | f(1)
+|     @@video_signal_characteristics_flag                   | f(1)
 |     if (video_signal_characteristics_flag)
 |         @@bit_depth_minus8                                | f(3)
 |         BitDepth = bit_depth_minus8 + 8
@@ -125,14 +125,16 @@ in the [AOMedia metadata registry](https://aomediacodec.github.io/metadata-regis
 |         }
 |     } else {
 |         @@num_y_points                                    | f(4)
-|         @@point_y_value_increment_bits_minus1             | f(3)
-|         BitsIncr = point_y_value_increment_bits_minus1 + 1
-|         point_y_value[ -1 ] = 0
-|         point_y_scaling_bits_minus5                       |f(2)
-|         BitsScal = point_y_scaling_bits_minus5 + 5
-|         for ( i = 0; i < num_y_points; i++ ) {
-|             @@point_y_value_increment[ i ]                | f(BitsIncr)
-|             @@point_y_scaling[ i ]                        | f(BitsScal)
+|         if (num_y_points) {
+|             @@point_y_value_increment_bits_minus1         | f(3)
+|             BitsIncr = point_y_value_increment_bits_minus1 + 1
+|             point_y_value[ -1 ] = 0
+|             point_y_scaling_bits_minus5                   |f(2)
+|             BitsScal = point_y_scaling_bits_minus5 + 5
+|             for ( i = 0; i < num_y_points; i++ ) {
+|                 @@point_y_value_increment[ i ]            | f(BitsIncr)
+|                 @@point_y_scaling[ i ]                    | f(BitsScal)
+|             }
 |         }
 |     }
 |     if ( luma_only ) {
@@ -161,16 +163,18 @@ in the [AOMedia metadata registry](https://aomediacodec.github.io/metadata-regis
 |             }
 |         } else {
 |             @@num_cb_points                               | f(4)
-|             @@point_cb_value_increment_bits_minus1        | f(3)
-|             BitsIncr = point_cb_value_increment_bits_minus1 + 1
-|             point_cb_value[ -1 ] = 0
-|             point_cb_scaling_bits_minus5                  |f(2)
-|             BitsScal = point_cb_scaling_bits_minus5 + 5
-|             cb_scaling_offset                             |f(8)
-|             for ( i = 0; i < num_cb_points; i++ ) {
-|                @@point_cb_value_increment[ i ]            | f(BitsIncr)
-|                @@point_cb_scaling[ i ]                    | f(BitsScal)
+|             if (num_cb_points) {
+|                 @@point_cb_value_increment_bits_minus1    | f(3)
+|                 BitsIncr = point_cb_value_increment_bits_minus1 + 1
+|                 point_cb_value[ -1 ] = 0
+|                 point_cb_scaling_bits_minus5              |f(2)
+|                 BitsScal = point_cb_scaling_bits_minus5 + 5
+|                 cb_scaling_offset                         |f(8)
+|                 for ( i = 0; i < num_cb_points; i++ ) {
+|                     @@point_cb_value_increment[ i ]       | f(BitsIncr)
+|                     @@point_cb_scaling[ i ]               | f(BitsScal)
 |             }
+|           }
 |         }
 |         if (predict_scaling) {
 |             @@predict_cr_scaling                          | f(1)
@@ -189,15 +193,17 @@ in the [AOMedia metadata registry](https://aomediacodec.github.io/metadata-regis
 |             }
 |         } else {
 |             @@num_cr_points                               | f(4)
-|             @@point_cr_value_increment_bits_minus1        | f(3)
-|             BitsIncr = point_cr_value_increment_bits_minus1 + 1
-|             point_cr_value[ -1 ] = 0
-|             point_cr_scaling_bits_minus5                  |f(2)
-|             BitsScal = point_cr_scaling_bits_minus5 + 5
-|             cr_scaling_offset                             |f(8)
-|             for ( i = 0; i < num_cr_points; i++ ) {
-|                 @@point_cr_value_increment[ i ]           | f(BitsIncr)
-|                 @@point_cr_scaling[ i ]                   | f(BitsScal)
+|             if (num_cr_points) {
+|                 @@point_cr_value_increment_bits_minus1    | f(3)
+|                 BitsIncr = point_cr_value_increment_bits_minus1 + 1
+|                 point_cr_value[ -1 ] = 0
+|                 point_cr_scaling_bits_minus5              |f(2)
+|                 BitsScal = point_cr_scaling_bits_minus5 + 5
+|                 cr_scaling_offset                         |f(8)
+|                 for ( i = 0; i < num_cr_points; i++ ) {
+|                     @@point_cr_value_increment[ i ]       | f(BitsIncr)
+|                     @@point_cr_scaling[ i ]               | f(BitsScal)
+|                 }
 |             }
 |         }
 |     }


### PR DESCRIPTION
Checking for num_y_points, num_cb_points, and num_cr_points and not sending unnecessary syntax elements if there are no scaling points signaled for the component