### PR TITLE
Update 02.terms.md

### DIFF
--- a/02.terms.md
+++ b/02.terms.md
@@ -47,39 +47,30 @@ Component
 
 Decoded picture
 
-: The picture reconstructed out of the bitstream by the decoder.
+: The picture reconstructed out of the bitstream by the video decoder.
 
+Field
 
-Video decoder
-
-: One embodiment of the video decoding process.
-
-Video decoding process
-
-: The process that derives decoded pictures from syntax elements, including any processing 
-  steps used prior to and generating decoded video pictures.
-
-Video encoding process
-
-: A process not specified in this Specification that generates a video bitstream.
-
-Film grain synthesis process
-
-: The process that derives film grain parameters from syntax elements, including any processing 
-  steps used  for the film grain synthesis process.
-
-Film grain synthesis module
-
-: One embodiment of the film grain synthesis process.
-
-Film grain analyzer
-
-: One embodiment of the film grain analysis process.
+: A collection of samples from alternate rows of a frame. A frame is composed of two fields, 
+a top field and a bottom field.
 
 Film grain analysis process
 
 : A process not specified in this Specification that generates film grain parameters
   that conforms to the description provided in this document.
+
+Film grain analyzer
+
+: One embodiment of the film grain analysis process.
+
+Film grain synthesis module
+
+: One embodiment of the film grain synthesis process.
+
+Film grain synthesis process
+
+: The process that derives film grain parameters from syntax elements, including any processing 
+  steps used for the film grain synthesis process.
 
 Flag
 
@@ -93,18 +84,6 @@ Frame
   where the top and bottom fields correspond to samples from even and odd numbered rows respectively. 
   A frame may be composed of one
   luma sample matrix (Y) and optionally two chroma sample matrices (U and V). 
-
-Field
-
-: A collection of samples from alternate rows of a frame. A frame is composed of two fields, 
-a top field and a bottom field.
-
-Picture
-
-:   The representation of video signals in the spatial domain, composed of one
-    luma sample matrix (Y) and , optionally, two chroma sample matrices (U and V) 
-    in a 4:2:0, 4:2:2, 4:4:4, 4:0:0 color format. The picture could be either a 
-    frame or a field.
 
 Key picture
 
@@ -121,6 +100,13 @@ Luma
 Parse
 
 : The procedure of getting the syntax element from the bitstream.
+
+Picture
+
+:   The representation of video signals in the spatial domain, composed of one
+    luma sample matrix (Y) and , optionally, two chroma sample matrices (U and V) 
+    in a 4:2:0, 4:2:2, 4:4:4, 4:0:0 color format. The picture could be either a 
+    frame or a field.
 
 Profile
 
@@ -173,4 +159,18 @@ Sequence
 Syntax element
 
 : An element of data represented in the bitstream.
+
+Video decoder
+
+: One embodiment of the video decoding process.
+
+Video decoding process
+
+: The process that derives decoded pictures from syntax elements, including any processing 
+  steps used prior to and after generating the decoded video pictures.
+
+Video encoding process
+
+: A process not specified in this Specification that generates a video bitstream.
+
 


### PR DESCRIPTION
Cleanup of a few terms and reorganization based on alphabetic order.

Some definitions seem not necessary, such as Profiles, but also we have a problematic definition for "Bitstream". That talks about coded pictures but not about film grain synthesis metadata. Maybe we should have three terms. A generic bitstream term for everything (optional), a video bitstream term, and a film grain synthesis metadata bitstream term. Then each one would have its purpose and we can distinguish other terms (such a syntax elements) appropriately. TBD