### PR TITLE
Restriction on parameters copy for picture resolution from not decoded picture resolution

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -111,10 +111,7 @@ scalability layers structure of the bitstream. In particular, the metadata assos
 should not refer to the film grain parameters associated with higher scalability layers.
 {:.alert .alert-info }
 
-**Note:** In case of the update_grain_flag equal to 0, the film grain synthesis module should use the parameters
-from the previous frame in the display order and not the coding order.
-{:.alert .alert-info }
-
+**film_grain_param_set_idx** specifies the index of a film grain parameter set. Up to 8 separate film grain parameter
 **film_grain_param_set_idx** specifies the index of a film grain parameter set. Up to 8 separate film grain parameter
 sets may be simultaneously stored by the film grain processing module.
 
@@ -133,15 +130,30 @@ av1_film_grain_params_function shall be stored in the memory location denoted by
 **grain_seed** specifies the starting value for the pseudo-random numbers used during film grain synthesis.
 
 **update_grain_flag** equal to 1 specifies the presence of a new set of film grain parameters. update_grain_flag equal to 0 
-specifies that the previous set of parameters in the frame display order should be used.
+specifies that a set of film grain parameters corresponding to the film_grain_param_set_idx value should be used.
 
-It is a requirement of bitstream conformance that for every distinct value of film_grain_param_set_idx used in a coded video
-sequence, the first frame in the display order with that value of film_grain_param_set_idx that has apply_grain_flag flag equal to 1
+It is a requirement of the specification conformance that for every distinct value of film_grain_param_set_idx used in a coded video
+sequence, the first frame in the decoding order with that value of film_grain_param_set_idx that has apply_grain_flag flag equal to 1
 have update_grain_flag equal to 1.
 
 **Note:** This requirement means that film grain parameters associated with a particular film_grain_param_set_idx value can only
-be inferred from previously signaled parameters in the display order with the same value of film_grain_param_set_idx
+be inferred from previously signaled parameters in the frame decoding order with the same value of film_grain_param_set_idx
 in the current coded video sequence.
+{:.alert .alert-info }
+
+It is a requirement of the specification conformance that if (i) update_grain_flag is equal to zero, (ii) apply_horz_resolution equal to 
+the luma horizontal resolution of the decoded frame » apply_units_resolution_log2, and (iii) apply_vert_resolution equal to the luma 
+vertical resolution of the decoded frame » apply_units_resolution_log2 then the film_grain_param_set_idx shall reference the 
+film grain parameters set that when the save_grain_params( film_grain_param_set_idx ) function was called, the following conditions were true
+(i) update_grain_flag was equal to 1, (ii) apply_horz_resolution was equal to 
+the luma horizontal resolution of the decoded frame » apply_units_resolution_log2, and (iii) apply_vert_resolution was equal to the luma 
+vertical resolution of the decoded frame » apply_units_resolution_log2. 
+
+**Note:** This requirement means that film grain parameters associated with the decoded picture resolution can only
+be inferred from previously signaled parameters that corresponded to the decoded picture resolution. This requirement is 
+intended to make sure that bitstreams that exercise variable decoded picture resolution do not copy the film grain parameters
+for the decoded picture resolutions from frames that were not at a decoded picture resolutions. This requirements helps
+decoders that only use (and store) film grain parameter sets that correspond to the decoded picture resolution.
 {:.alert .alert-info }
 
 **tempGrainSeed** is a temporary variable that is used to preserve the value of grain_seed when load_grain_params is called.


### PR DESCRIPTION
This adds a restriction that prohibits prediction parameters from the decoded picture resolution from other resolutions
This PR also fixes bud related to a previous approach decode parameters in the display order.