### PR TITLE
Add note about parameter sets for pictures in scalable streams

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -74,6 +74,13 @@ correspond to the same resolution, and film grain parameter sets related to the 
 decoded picture shall each use a unique of film_grain_param_set_idx.
 {:.alert .alert-info }
 
+**Note:** This implies that if multiple distinct decoded pictures could be generated from
+the same bitstream (for example, when scalable layers are present with operating points
+which produce different resolutions) and film grain parameter sets are present, then
+a film grain parameter set must be available matching the parameters of each possible
+decoded picture.
+{:.alert .alert-info }
+
 ### Film grain parameter payload semantics
 **payload_less_than_4byte_flag** equal to 1 specifies that the number of bytes used by the data in the current
 av1_film_grain_payload is less than four bytes.  payload_less_than_4byte_flag equal to 0 specifies that the number of

--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -74,7 +74,7 @@ correspond to the same resolution, and film grain parameter sets related to the 
 decoded picture shall each use a unique of film_grain_param_set_idx.
 {:.alert .alert-info }
 
-**Note:** This implies that if multiple distinct decoded pictures could be generated from
+**Note:** The conformance statements above mean that if multiple distinct decoded pictures could be generated from
 the same bitstream (for example, when scalable layers are present with operating points
 which produce different resolutions) and film grain parameter sets are present, then
 a film grain parameter set must be available matching the parameters of each possible


### PR DESCRIPTION
This is clarifying the backward compatibility case for existing AV1 decoder implementations which support scalability and only apply film grain as part of the decoding process.