### PR TITLE
Offset AR coefficients to get the AV1 range

### DIFF
--- a/07.bitstream.semantics.md
+++ b/07.bitstream.semantics.md
@@ -536,7 +536,7 @@ luma and chroma.
 The values of auto-regressive coefficients plus 128 for the luma component ArCoeffsYPlus128[ i ] are derived as follows
 ~~~~~ c
 for ( i = 0; i < numPosLuma; i++ )
-    ArCoeffsYPlus128[ i ] = ar_coeffs_y[ i ] - (1<<(BitsArY - 1)).
+    ArCoeffsYPlus128[ i ] = ar_coeffs_y[ i ] - (1<<(BitsArY - 1)) + 128.
 ~~~~~
 
 **bits_per_ar_coeff_cb_minus5** plus 5 specifies the number of bits used to signal ar_coeffs_cb[ i ].
@@ -546,7 +546,7 @@ for ( i = 0; i < numPosLuma; i++ )
 The values of the auto-regressive coefficients plus 128 for the Cb component ArCoeffsCbPlus128[ i ] are derived as follows:
 ~~~~~ c
 for ( i = 0; i < numPosChroma; i++ )
-    ArCoeffsCbPlus128[ i ] = ar_coeffs_cb[ i ] - (1<<(BitsArCb - 1)).
+    ArCoeffsCbPlus128[ i ] = ar_coeffs_cb[ i ] - (1<<(BitsArCb - 1)) + 128.
 ~~~~~
 
 **bits_per_ar_coeff_cr_minus5** plus 5 specifies the number of bits used to signal ar_coeffs_cr[ i ].
@@ -556,7 +556,7 @@ for ( i = 0; i < numPosChroma; i++ )
 The values of the auto-regressive coefficients plus 128 for the Cr component ArCoeffsCrPlus128[ i ] are derived as follows:
 ~~~~~ c
 for ( i = 0; i < numPosChroma; i++ )
-        ArCoeffsCrPlus128[ i ] = ar_coeffs_cr[ i ] - (1<<(BitsArCr - 1)).
+        ArCoeffsCrPlus128[ i ] = ar_coeffs_cr[ i ] - (1<<(BitsArCr - 1)) + 128.
 ~~~~~
 
 **ar_coeff_shift_minus6** specifies the range of the auto-regressive coefficients. Values of 0, 1, 2, and 3


### PR DESCRIPTION
Shift AR parameters to get them to AV1 range. An alternative would be to not subtract 128 in the film grain synthesis algorithm, but this would make the implementation slightly different from AV1.  