### PR TITLE
Bold all bitstream syntax elements

### DIFF
--- a/06.bitstream.syntax.md
+++ b/06.bitstream.syntax.md
@@ -95,9 +95,9 @@ each of the syntax elements is presented in [Section 6][].
 |     @@luma_only_flag                                           | f(1)
 |     SubX = SubY = 0
 |     if ( !luma_only_flag ) {
-|          subsampling_x                                    | f(1)
+|          @@subsampling_x                                  | f(1)
 |          SubX = subsampling_x
-|          subsampling_y                                    | f(1)
+|          @@subsampling_y                                  | f(1)
 |          SubY = subsampling_y
 |     }
 |     @@video_signal_characteristics_flag                   | f(1)
@@ -106,10 +106,10 @@ each of the syntax elements is presented in [Section 6][].
 |         BitDepth = bit_depth_minus8 + 8
 |         @@cicp_info_present_flag                          | f(1)
 |         if ( cicp_info_present_flag ) {
-|             color_primaries                               | f(8)
-|             transfer_characteristics                      | f(8)
-|             matrix_coefficients                           | f(8)
-|             video_full_range_flag                         | f(1)
+|             @@color_primaries                             | f(8)
+|             @@transfer_characteristics                    | f(8)
+|             @@matrix_coefficients                         | f(8)
+|             @@video_full_range_flag                       | f(1)
 |         }
 |     }
 |     @@predict_scaling_flag                                     | f(1)
@@ -133,7 +133,7 @@ each of the syntax elements is presented in [Section 6][].
 |         if (num_y_points) {
 |             @@point_y_value_increment_bits_minus1         | f(3)
 |             bitsIncr = point_y_value_increment_bits_minus1 + 1
-|             point_y_scaling_bits_minus5                   |f(2)
+|             @@point_y_scaling_bits_minus5                 |f(2)
 |             bitsScal = point_y_scaling_bits_minus5 + 5
 |             for ( i = 0; i < num_y_points; i++ ) {
 |                 @@point_y_value_increment[ i ]            | f(bitsIncr)
@@ -212,7 +212,7 @@ each of the syntax elements is presented in [Section 6][].
 |     numPosLuma = 2 * ar_coeff_lag * ( ar_coeff_lag + 1 )
 |     if ( num_y_points \|\| predict_y_scaling_flag ) {
 |         numPosChroma = numPosLuma + 1
-|         bits_per_ar_coeff_y_minus5                        | f(2)
+|         @@bits_per_ar_coeff_y_minus5                      | f(2)
 |         BitsArY = bits_per_ar_coeff_y_minus5 + 5
 |         for ( i = 0; i < numPosLuma; i++ )
 |             @@ar_coeffs_y[ i ]                            | f(BitsArY)
@@ -220,13 +220,13 @@ each of the syntax elements is presented in [Section 6][].
 |         numPosChroma = numPosLuma
 |     }
 |     if ( chroma_scaling_from_luma_flag \|\| num_cb_points  \|\| predict_cb_scaling_flag ) {
-|         bits_per_ar_coeff_cb_minus5                       | f(2)
+|         @@bits_per_ar_coeff_cb_minus5                     | f(2)
 |         BitsArCb = bits_per_ar_coeff_cb_minus5 + 5
 |         for ( i = 0; i < numPosChroma; i++ )
 |             @@ar_coeffs_cb[ i ]                           | f(BitsArCb)
 |     }
 |     if ( chroma_scaling_from_luma_flag \|\| num_cr_points  \|\| predict_cr_scaling_flag ) {
-|         bits_per_ar_coeff_cr_minus5                       | f(2)
+|         @@bits_per_ar_coeff_cr_minus5                     | f(2)
 |         BitsArCr = bits_per_ar_coeff_cr_minus5 + 5
 |         for ( i = 0; i < numPosChroma; i++ )
 |             @@ar_coeffs_cr[ i ]                           | f(BitsArCr)


### PR DESCRIPTION
Fixes: https://github.com/AOMediaCodec/afgs1-spec/issues/117